### PR TITLE
docker: Add app-rolling docker compose profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Base Stage ----
-# Sets up No, pnpm, and copies package manifests.
+# Sets up Node, pnpm, and copies package manifests.
 FROM node:22-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Base Stage ----
-# Sets up Node, pnpm, and copies package manifests.
+# Sets up No, pnpm, and copies package manifests.
 FROM node:22-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -68,6 +68,37 @@ RUN if [ "$VINUMC_SOURCE" = "release" ]; then \
       chmod +x /usr/local/bin/vinumc; \
     fi
 
+
+RUN pnpm build
+
+FROM base AS rolling-build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    meson \
+    ninja-build \
+    build-essential \
+    bison \
+    flex \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/vinumdoc/vinum.git /tmp/vinum-src && \
+    cd /tmp/vinum-src && \
+    meson setup builddir -Dprefer_static=true -Ddefault_library=static && \
+    meson compile -C builddir && \
+    cp /tmp/vinum-src/builddir/subprojects/vinumc/vinumc /usr/local/bin/vinumc && \
+    chmod +x /usr/local/bin/vinumc && \
+    rm -rf /tmp/vinum-src
+
+WORKDIR /app
+
+COPY . /app
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+
+ARG DATABASE_URL="file:./local.db"
+ARG NODE_ENV
+ENV NODE_ENV=${NODE_ENV:-production}
 
 RUN pnpm build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     profiles:
       - dev
       - dev-local
+      - dev-rolling
       - prod
 
   app-release:
@@ -41,6 +42,30 @@ services:
       - yjs-ws
     profiles:
       - dev-release
+
+  app-rolling:
+    build:
+      context: .
+      target: rolling-build
+      args:
+        NODE_ENV: ${NODE_ENV:-production}
+    image: calix-rolling
+    command: pnpm dev --host 0.0.0.0
+    platform: linux/amd64
+    volumes:
+      - .:/app:cached
+      - /app/node_modules
+    ports:
+      - '5173:5173'
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      VINUMC_SOURCE: rolling
+      PUBLIC_YJS_WS_URL: ${PUBLIC_YJS_WS_URL:-ws://localhost:1234}
+    depends_on:
+      - db
+      - yjs-ws
+    profiles:
+      - dev-rolling
 
   app-local:
     build:
@@ -110,6 +135,7 @@ services:
       - dev
       - dev-release
       - dev-local
+      - dev-rolling
       - prod
 
 volumes:


### PR DESCRIPTION
Add an profile that fetches the latest vinumc branch for easy development.

For the server the docker compose build should be ran without layer caching, so it doesn't cache the git fetching. Like below:

```
docker compose --profile dev-rolling build --no-cache app-rolling
docker compose --profile dev-rolling up -d
```
