### PR TITLE
projects/[id]/page: Also save the content to the file.body on change

### DIFF
--- a/src/routes/projects/[id]/+page.svelte
+++ b/src/routes/projects/[id]/+page.svelte
@@ -79,11 +79,10 @@
 	function handleCodeChange(newCode: string) {
 		activeContent = newCode;
 		
-		const currentFile = files.find((f) => f.relativePath === activeFilePath);
-    if (currentFile) {
-        currentFile.body = newCode;
-    }
-    
+		const file = files.find((f) => f.relativePath === activeFilePath);
+		if (file && !file.isBinary) {
+			file.body = activeContent;
+		}
 		triggerDebouncedCompile();
 	}
 


### PR DESCRIPTION
If you select the file again on the file selector it resets the editor content to when the page was loaded. This is happening because we don't update the content in the file body when a change happens on the editor.

Fixes: #32